### PR TITLE
add rudimentary oracle into test generation

### DIFF
--- a/Source/Dafny/AST/DafnyAst.cs
+++ b/Source/Dafny/AST/DafnyAst.cs
@@ -12731,7 +12731,7 @@ namespace Microsoft.Dafny {
   }
 
   public class NameSegment : ConcreteSyntaxExpression {
-    public readonly string Name;
+    public string Name;
     public readonly List<Type> OptTypeArguments;
     public NameSegment(IToken tok, string name, List<Type> optTypeArguments)
       : base(tok) {
@@ -12901,7 +12901,7 @@ namespace Microsoft.Dafny {
     }
   }
   public class TopDownVisitor<State> {
-    public void Visit(Expression expr, State st) {
+    public virtual void Visit(Expression expr, State st) {
       Contract.Requires(expr != null);
       if (VisitOneExpr(expr, ref st)) {
         // recursively visit all subexpressions and all substatements

--- a/Source/DafnyTestGeneration/DeepCopy.cs
+++ b/Source/DafnyTestGeneration/DeepCopy.cs
@@ -1,0 +1,143 @@
+/*
+Source code is released under the MIT license.
+
+The MIT License (MIT)
+Copyright (c) 2014 Burtsev Alexey
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+using System.Collections.Generic;
+using System.Reflection;
+using System.ArrayExtensions;
+
+namespace System
+{
+    public static class ObjectExtensions
+    {
+        private static readonly MethodInfo CloneMethod = typeof(Object).GetMethod("MemberwiseClone", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        public static bool IsPrimitive(this Type type)
+        {
+            if (type == typeof(String)) return true;
+            return (type.IsValueType & type.IsPrimitive);
+        }
+
+        public static Object Copy(this Object originalObject)
+        {
+            return InternalCopy(originalObject, new Dictionary<Object, Object>(new ReferenceEqualityComparer()));
+        }
+        private static Object InternalCopy(Object originalObject, IDictionary<Object, Object> visited)
+        {
+            if (originalObject == null) return null;
+            var typeToReflect = originalObject.GetType();
+            if (IsPrimitive(typeToReflect)) return originalObject;
+            if (visited.ContainsKey(originalObject)) return visited[originalObject];
+            if (typeof(Delegate).IsAssignableFrom(typeToReflect)) return null;
+            var cloneObject = CloneMethod.Invoke(originalObject, null);
+            if (typeToReflect.IsArray)
+            {
+                var arrayType = typeToReflect.GetElementType();
+                if (IsPrimitive(arrayType) == false)
+                {
+                    Array clonedArray = (Array)cloneObject;
+                    clonedArray.ForEach((array, indices) => array.SetValue(InternalCopy(clonedArray.GetValue(indices), visited), indices));
+                }
+
+            }
+            visited.Add(originalObject, cloneObject);
+            CopyFields(originalObject, visited, cloneObject, typeToReflect);
+            RecursiveCopyBaseTypePrivateFields(originalObject, visited, cloneObject, typeToReflect);
+            return cloneObject;
+        }
+
+        private static void RecursiveCopyBaseTypePrivateFields(object originalObject, IDictionary<object, object> visited, object cloneObject, Type typeToReflect)
+        {
+            if (typeToReflect.BaseType != null)
+            {
+                RecursiveCopyBaseTypePrivateFields(originalObject, visited, cloneObject, typeToReflect.BaseType);
+                CopyFields(originalObject, visited, cloneObject, typeToReflect.BaseType, BindingFlags.Instance | BindingFlags.NonPublic, info => info.IsPrivate);
+            }
+        }
+
+        private static void CopyFields(object originalObject, IDictionary<object, object> visited, object cloneObject, Type typeToReflect, BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.FlattenHierarchy, Func<FieldInfo, bool> filter = null)
+        {
+            foreach (FieldInfo fieldInfo in typeToReflect.GetFields(bindingFlags))
+            {
+                if (filter != null && filter(fieldInfo) == false) continue;
+                if (IsPrimitive(fieldInfo.FieldType)) continue;
+                var originalFieldValue = fieldInfo.GetValue(originalObject);
+                var clonedFieldValue = InternalCopy(originalFieldValue, visited);
+                fieldInfo.SetValue(cloneObject, clonedFieldValue);
+            }
+        }
+        public static T Copy<T>(this T original)
+        {
+            return (T)Copy((Object)original);
+        }
+    }
+
+    public class ReferenceEqualityComparer : EqualityComparer<Object>
+    {
+        public override bool Equals(object x, object y)
+        {
+            return ReferenceEquals(x, y);
+        }
+        public override int GetHashCode(object obj)
+        {
+            if (obj == null) return 0;
+            return obj.GetHashCode();
+        }
+    }
+
+    namespace ArrayExtensions
+    {
+        public static class ArrayExtensions
+        {
+            public static void ForEach(this Array array, Action<Array, int[]> action)
+            {
+                if (array.LongLength == 0) return;
+                ArrayTraverse walker = new ArrayTraverse(array);
+                do action(array, walker.Position);
+                while (walker.Step());
+            }
+        }
+
+        internal class ArrayTraverse
+        {
+            public int[] Position;
+            private int[] maxLengths;
+
+            public ArrayTraverse(Array array)
+            {
+                maxLengths = new int[array.Rank];
+                for (int i = 0; i < array.Rank; ++i)
+                {
+                    maxLengths[i] = array.GetLength(i) - 1;
+                }
+                Position = new int[array.Rank];
+            }
+
+            public bool Step()
+            {
+                for (int i = 0; i < Position.Length; ++i)
+                {
+                    if (Position[i] < maxLengths[i])
+                    {
+                        Position[i]++;
+                        for (int j = 0; j < i; j++)
+                        {
+                            Position[j] = 0;
+                        }
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+    }
+
+}

--- a/Source/DafnyTestGeneration/Main.cs
+++ b/Source/DafnyTestGeneration/Main.cs
@@ -81,8 +81,8 @@ namespace DafnyTestGeneration {
     /// </summary>
     /// <returns></returns>
     public static IEnumerable<TestMethod> GetTestMethodsForProgram(
-      Program program, DafnyInfo? dafnyInfo = null) {
-
+      Program program, DafnyInfo? dafnyInfo = null, OracleInfo? oracleInfo = null) {
+      oracleInfo ??= new OracleInfo(program);
       dafnyInfo ??= new DafnyInfo(program);
       var modifications = GetModifications(program).ToList();
 
@@ -105,7 +105,7 @@ namespace DafnyTestGeneration {
         if (log == null) {
           continue;
         }
-        var testMethod = new TestMethod(dafnyInfo, log);
+        var testMethod = new TestMethod(dafnyInfo, oracleInfo, log);
         if (testMethods.Contains(testMethod)) {
           continue;
         }

--- a/Source/DafnyTestGeneration/OracleInfo.cs
+++ b/Source/DafnyTestGeneration/OracleInfo.cs
@@ -1,0 +1,167 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Dafny;
+using Token = Microsoft.Boogie.Token;
+using static System.ObjectExtensions;
+
+namespace DafnyTestGeneration {
+
+  /// <summary> Extract oracle-related info from a parsed Dafny program </summary>
+  public class OracleInfo {
+
+    // method -> (list of argument names)
+    public readonly Dictionary<string, List<string>> argNames;
+    //method -> (list of return variable names)
+    public readonly Dictionary<string, List<string>> retNames;
+
+    // method -> (list of ensures)
+    public readonly Dictionary<string, List<string>> ensList;
+
+    public Dictionary<string, List<AttributedExpression>> ensObjects;
+    public readonly List<string> tempData;
+    public OracleInfo(Microsoft.Dafny.Program program) {
+      argNames = new Dictionary<string, List<string>>();
+      retNames = new Dictionary<string, List<string>>();
+      ensList = new Dictionary<string, List<string>>();
+      ensObjects = new Dictionary<string, List<AttributedExpression>>();
+      tempData = new List<string>();
+      var visitor = new OracleInfoExtractor(this);
+      visitor.Visit(program);
+    }
+
+    public IList<string> GetArgNames(string method) {
+      return argNames[method];
+    }    
+    public IList<string> GetRetNames(string method) {
+      return retNames[method];
+    }
+
+    public IList<string> GetEnsList(string method) {
+      return ensList[method];
+    }
+
+    /// <summary>
+    /// Fills in the Oracle Info data by traversing the AST
+    /// </summary>
+    private class OracleInfoExtractor : BottomUpVisitor {
+
+      private readonly OracleInfo info;
+
+      // path to a method in the tree of modules and classes:
+      private readonly List<string> path;
+
+      internal OracleInfoExtractor(OracleInfo info) {
+        this.info = info;
+        path = new List<string>();
+      }
+
+      internal void Visit(Microsoft.Dafny.Program p) {
+        Visit(p.DefaultModule);
+      }
+
+      private void Visit(TopLevelDecl d) {
+        if (d is LiteralModuleDecl moduleDecl) {
+          Visit(moduleDecl);
+        } else if (d is ClassDecl classDecl) {
+          Visit(classDecl);
+        }
+      }
+
+      private void Visit(LiteralModuleDecl d) {
+        if (d.Name.Equals("_module")) {
+          d.ModuleDef.TopLevelDecls.ForEach(Visit);
+          return;
+        }
+        path.Add(d.Name);
+        d.ModuleDef.TopLevelDecls.ForEach(Visit);
+        path.RemoveAt(path.Count - 1);
+      }
+
+      private void Visit(ClassDecl d) {
+        if (d.Name == "_default") {
+          d.Members.ForEach(Visit);
+          return;
+        }
+        path.Add(d.Name);
+        d.Members.ForEach(Visit);
+        path.RemoveAt(path.Count - 1);
+      }
+
+      private void Visit(MemberDecl d) {
+        if (d is Method method) {
+          Visit(method);
+        }
+      }
+
+      private new void Visit(Method m) {
+        var methodName = m.Name;
+        if (path.Count != 0) {
+          methodName = $"{string.Join(".", path)}.{methodName}";
+        }
+        var argNames = m.Ins.Select(arg => arg.Name.ToString()).ToList();
+        var retNames = m.Outs.Select(ret => ret.Name.ToString()).ToList();
+        var ensList = m.Ens.Select(ens => Printer.ExprToString(ens.E)).ToList();
+        var ensObjects = m.Ens;
+        info.argNames[methodName] = argNames;
+        info.retNames[methodName] = retNames;
+        info.ensList[methodName] = ensList;
+        info.ensObjects[methodName] = ensObjects;
+      }
+    }
+
+  }
+    public class OracleEnsReplacer<State> : TopDownVisitor<State> {
+      /// <summary> Visitor that replaces variables in an ensures using a given map</summary>
+        public List<AttributedExpression> ens;
+        private Dictionary<string, string> varMap;
+
+        private Dictionary<string, string> oldVarMap;
+
+        private bool inOldExpr;
+        public OracleEnsReplacer(List<AttributedExpression> ens, Dictionary<string, string> varMap, Dictionary<string, string> oldVarMap, State st) {
+            this.ens = System.ObjectExtensions.Copy(ens);
+            this.varMap = varMap;
+            this.oldVarMap = oldVarMap;
+            this.inOldExpr = false;
+            Visit(this.ens, st);
+        }
+        override protected bool VisitOneExpr(Expression expr, ref State st) {
+            if (expr is Microsoft.Dafny.NameSegment) {
+                NameSegment nameSegment = (NameSegment)expr;
+                if (this.inOldExpr){
+                    if (this.oldVarMap.ContainsKey(nameSegment.Name)){
+                        nameSegment.Name = this.oldVarMap[nameSegment.Name];
+                    }
+                }
+                else{
+                    if (this.varMap.ContainsKey(nameSegment.Name)){
+                        nameSegment.Name = this.varMap[nameSegment.Name];
+                    }
+                }
+            }
+            return true;
+        }
+
+        public override void Visit(Expression expr, State st) {
+            //Contract.Requires(expr != null);
+            if (expr.GetType().ToString() == "Microsoft.Dafny.OldExpr"){
+                this.inOldExpr = true;
+            }
+            if (VisitOneExpr(expr, ref st)) {
+                // recursively visit all subexpressions and all substatements
+                foreach (Expression subExpr in expr.SubExpressions)
+                {
+                    Visit(subExpr, st);
+                }
+                if (expr is StmtExpr) {
+                    // a StmtExpr also has a sub-statement
+                    var e = (StmtExpr)expr;
+                    Visit(e.S, st);
+                }
+            }
+            if (expr.GetType().ToString() == "Microsoft.Dafny.OldExpr"){
+                this.inOldExpr = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
The JUnit5.assertTrue line (testMethod.cs line 409) can be uncommented, although it really only works in Java for extremely simple examples.