### PR TITLE
fix underscore names

### DIFF
--- a/Source/Dafny/Compilers/Compiler-Csharp.cs
+++ b/Source/Dafny/Compilers/Compiler-Csharp.cs
@@ -3258,12 +3258,13 @@ namespace Microsoft.Dafny {
       }
       var args = Attributes.FindExpressions(decl.Attributes, "test");
       if (args.Count == 2 && args[0] is LiteralExpr && args[1] is LiteralExpr) {
-        LiteralExpr sourceType = (LiteralExpr) args[0];
+        LiteralExpr sourceType = (LiteralExpr)args[0];
         if (sourceType.Value.ToString().Equals("MethodSource")) {
-          Method m = (Method) decl;
-          LiteralExpr methodNameExpr = (LiteralExpr) args[1];
+          Method m = (Method)decl;
+          LiteralExpr methodNameExpr = (LiteralExpr)args[1];
           string dafnyStructure = WriteDafnyStructure(m, wr);
-          WriteGlueCode(wr, methodNameExpr.Value.ToString(), dafnyStructure, m.Ins.Count);
+          string compiledSourceName = NonglobalVariable.CompilerizeName(methodNameExpr.Value.ToString());
+          WriteGlueCode(wr, compiledSourceName, dafnyStructure, m.Ins.Count);
           return;
         }
       }

--- a/Source/Dafny/Compilers/Compiler-java.cs
+++ b/Source/Dafny/Compilers/Compiler-java.cs
@@ -521,18 +521,17 @@ namespace Microsoft.Dafny {
         return;
       }
       var args = Attributes.FindExpressions(decl.Attributes, "test");
-      Console.Out.WriteLine(decl.Name);
       if (args.Count == 2 && args[0] is LiteralExpr && args[1] is LiteralExpr) {
         LiteralExpr sourceType = (LiteralExpr)args[0];
         if (sourceType.Value.ToString().Equals("MethodSource")) {
-          Method m = (Method) decl;
-          LiteralExpr methodNameExpr = (LiteralExpr) args[1];
+          Method m = (Method)decl;
+          LiteralExpr methodNameExpr = (LiteralExpr)args[1];
           string dafnyStructure = WriteDafnyStructure(m, wr);
-          WriteGlueCode(wr, methodNameExpr.Value.ToString(), dafnyStructure, m.Ins.Count);
+          string compiledSourceName = NonglobalVariable.CompilerizeName(methodNameExpr.Value.ToString());
+          WriteGlueCode(wr, compiledSourceName, dafnyStructure, m.Ins.Count);
           return;
         }
-      }
-      else {
+      } else {
         wr.WriteLine("@org.junit.jupiter.api.Test");
         return;
       }

--- a/Source/Dafny/Compilers/Compiler.cs
+++ b/Source/Dafny/Compilers/Compiler.cs
@@ -1803,7 +1803,7 @@ namespace Microsoft.Dafny {
               Error(m.tok, "Method {0} has no body", errorWr, m.FullName);
             }
           } else if (m.Body == null && (!(c is TraitDecl) || m.IsStatic) &&
-            (!DafnyOptions.O.DisallowExterns && (Attributes.Contains(m.Attributes, "dllimport") || (IncludeExternMembers && Attributes.Contains(m.Attributes, "extern")))) &&
+            !DafnyOptions.O.DisallowExterns && (Attributes.Contains(m.Attributes, "dllimport") || (IncludeExternMembers && Attributes.Contains(m.Attributes, "extern"))) &&
             DafnyOptions.O.CompileTarget == DafnyOptions.CompilationTarget.Java) {
             // A (ghost or non-ghost) method must always have a body, except if it's an instance method in a trait.
             if (Attributes.Contains(m.Attributes, "axiom")) {


### PR DESCRIPTION
Since the compiled name of a method is different from its Dafny counterpart, this branch uses `CompilerizeName` in order to ensure the specified method source is consistent with the compiled name of the actual method declaration.

Also, some formatting/whitespace rules have been followed